### PR TITLE
修复getLong方法的逻辑判断错误

### DIFF
--- a/src/AtomicManager.php
+++ b/src/AtomicManager.php
@@ -38,7 +38,7 @@ class AtomicManager
 
     function getLong($name):?Long
     {
-        if(!isset($this->listForLong[$name])){
+        if(isset($this->listForLong[$name])){
             return $this->listForLong[$name];
         }else{
             return null;


### PR DESCRIPTION
修复getLong方法的逻辑判断错误